### PR TITLE
Update parser so that emojis that are without spaces next to an emote are displayed (hope this is correct?)

### DIFF
--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -174,10 +174,19 @@ class Parser {
 		const twitchEmotes = cosmetics.twitch.emotes || [];
 		const stvEmotes = cosmetics.sevenTv.emotes;
 
-		const words = message.split(' ');
 		let index = 0;
 
-		for (const word of words) {
+		const wordRegex = /(\p{Emoji}|\bhttps?:\/\/\S+\b|\w+|\s+|[^\w\s])/gu;
+		const parts = [...message.matchAll(wordRegex)].map((m) => m[0]);
+
+		for (const word of parts) {
+			const clean = word.trim();
+
+			if (!clean) {
+				index += word.length;
+				continue;
+			}
+
 			const twitchEmote = twitchEmotes.find((e) => e.start === index);
 
 			index += Array.from(word).length + 1;
@@ -211,7 +220,13 @@ class Parser {
 				continue;
 			}
 
-			processed.push({ type: 'text', content: word });
+			if (/\p{Emoji}/u.test(word)) {
+				processed.push({ type: 'emoji', content: word });
+			} else {
+				processed.push({ type: 'text', content: word });
+			}
+
+			index += word.length;
 		}
 
 		return processed;

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -9,7 +9,8 @@ export type TwitchBadge = {
 export type ProcessedWord =
 	| { type: 'text'; content: string }
 	| { type: 'emote'; content: string; id: string; url: string; aspectRatio: number }
-	| { type: 'link'; content: string; url: string };
+	| { type: 'link'; content: string; url: string }
+	| { type: 'emoji'; content: string };
 
 export type Emote = {
 	emoteId: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
Adjustment that if an emoji without spaces is next to a 7tv emote it is still displayed